### PR TITLE
Specify java compiler version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.7</java.version>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Fix for the "annotations are not supported in -source 1.4" error given by maven when building from the command line.
